### PR TITLE
Add SpanData to BorrowData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rls-data"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-data"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Data structures used by the RLS and Rust compiler"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl Analysis {
 
 // DefId::index is a newtype and so the JSON serialisation is ugly. Therefore
 // we use our own Id which is the same, but without the newtype.
-#[derive(Clone, Copy, Debug, RustcDecodable, RustcEncodable, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, RustcDecodable, RustcEncodable, PartialEq, Eq, Hash)]
 pub struct Id {
     pub krate: u32,
     pub index: u32,
@@ -268,6 +268,7 @@ pub struct BorrowData {
     pub scopes: Vec<Scope>,
     pub loans: Vec<Loan>,
     pub moves: Vec<Move>,
+    pub span: Option<SpanData>,
 }
 
 #[cfg(feature = "borrows")]


### PR DESCRIPTION
This is needed to support the Span search trees in `rls-analysis`