### PR TITLE
Add TupleVariant and StructVariant DefKinds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,12 @@ pub enum DefKind {
     // value = variant names
     Enum,
     // value = enum name + variant name + types
+    TupleVariant,
+    // value = enum name + name + fields
+    StructVariant,
+    // value = variant name + types
     Tuple,
-    // value = [enum name +] name + fields
+    // value = name + fields
     Struct,
     Union,
     // value = signature


### PR DESCRIPTION
In order to support more fine-grained detail about Enum variants, add new DefKinds. This will help RLS and its clients to be more specific in symbol classifications for the variants.

This fixes #9.