### PR TITLE
Add crate disambiguators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-data"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Data structures used by the RLS and Rust compiler"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,14 @@ pub struct Id {
     pub index: u32,
 }
 
-/// This represents a globally unique crate identifier, which should allow
-/// for differentiation between different crate targets or versions and should
-/// point to the same crate when pulled by different other, dependent crates.
+/// Crate name, along with its disambiguator (128-bit hash) represents a globally
+/// unique crate identifier, which should allow for differentiation between
+/// different crate targets or versions and should point to the same crate when
+/// pulled by different other, dependent crates.
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable, PartialEq, Eq, Hash)]
 pub struct GlobalCrateId {
     pub name: String,
-    pub disambiguator: String,
+    pub disambiguator: (u64, u64),
 }
 
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,15 @@ pub struct Id {
     pub index: u32,
 }
 
+/// This represents a globally unique crate identifier, which should allow
+/// for differentiation between different crate targets or versions and should
+/// point to the same crate when pulled by different other, dependent crates.
+#[derive(Debug, Clone, RustcDecodable, RustcEncodable, PartialEq, Eq, Hash)]
+pub struct GlobalCrateId {
+    pub name: String,
+    pub disambiguator: String,
+}
+
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]
 pub struct SpanData {
     pub file_name: PathBuf,
@@ -95,9 +104,8 @@ pub struct SpanData {
 
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]
 pub struct CratePreludeData {
-    pub crate_name: String,
+    pub crate_id: GlobalCrateId,
     pub crate_root: String,
-    pub crate_disambiguator: String,
     pub external_crates: Vec<ExternalCrateData>,
     pub span: SpanData,
 }
@@ -111,8 +119,7 @@ pub struct ExternalCrateData {
     /// always 0, so these should start from 1 and range should be contiguous,
     /// e.g. from 1 to n for n external crates.
     pub num: u32,
-    pub name: String,
-    pub disambiguator: String,
+    pub id: GlobalCrateId,
 }
 
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub struct SpanData {
 pub struct CratePreludeData {
     pub crate_name: String,
     pub crate_root: String,
+    pub crate_disambiguator: String,
     pub external_crates: Vec<ExternalCrateData>,
     pub span: SpanData,
 }
@@ -104,9 +105,14 @@ pub struct CratePreludeData {
 /// Data for external crates in the prelude of a crate.
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]
 pub struct ExternalCrateData {
-    pub name: String,
-    pub num: u32,
+    /// Source file where the external crate is declared.
     pub file_name: String,
+    /// A crate-local crate index of an external crate. Local crate index is
+    /// always 0, so these should start from 1 and range should be contiguous,
+    /// e.g. from 1 to n for n external crates.
+    pub num: u32,
+    pub name: String,
+    pub disambiguator: String,
 }
 
 #[derive(Debug, Clone, RustcDecodable, RustcEncodable)]


### PR DESCRIPTION
Needed for https://github.com/nrc/rls-analysis/issues/93.

This allows to distinguish between different versions of a crate or
different crate targets such as bin or lib.

Will make a PR with changes to librustc_save_analysis generation after a new version with these changes will be published.