### PR TITLE
add config option to filter reachable items

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     /// If true only includes data for public items in a crate (useful for
     /// library crates).
     pub pub_only: bool,
+    /// If true only includes data for items reachable from the crate root.
+    pub reachable_only: bool,
     /// True if and only if the analysed crate is part of the standard Rust distro.
     pub distro_crate: bool,
     /// Include signature information.


### PR DESCRIPTION
Starting work on https://github.com/nrc/rls-analysis/issues/79.

Does this option make sense as another boolean? Should it be combined into an enum along with `pub_only`?