### PR TITLE
Updates for save-analysis

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,7 @@ pub struct Relation {
     pub kind: RelationKind,
     pub from: Id,
     pub to: Id,
+    pub id: u32,
 }
 
 #[derive(Debug, RustcDecodable, RustcEncodable, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,12 +254,13 @@ pub struct Relation {
     pub kind: RelationKind,
     pub from: Id,
     pub to: Id,
-    pub id: u32,
 }
 
 #[derive(Debug, RustcDecodable, RustcEncodable, Clone, Copy, PartialEq, Eq)]
 pub enum RelationKind {
-    Impl,
+    Impl {
+        id: u32,
+    },
     SuperTrait,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub struct Impl {
     pub attributes: Vec<Attribute>,
 }
 
-#[derive(Debug, RustcDecodable, RustcEncodable, Clone, PartialEq, Eq)]
+#[derive(Debug, RustcDecodable, RustcEncodable, Clone, PartialEq, Eq, Hash)]
 pub enum ImplKind {
     // impl Foo { ... }
     Inherent,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub struct Impl {
     pub attributes: Vec<Attribute>,
 }
 
-#[derive(Debug, RustcDecodable, RustcEncodable, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, RustcDecodable, RustcEncodable, Clone, PartialEq, Eq)]
 pub enum ImplKind {
     // impl Foo { ... }
     Inherent,


### PR DESCRIPTION
To emit `rls-data::Impl` in [rust save-analysis](https://github.com/rust-lang/rust/pull/47657), we need some changes.