### PR TITLE
Add a version field in the rls-data Analysis structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use config::Config;
 pub struct Analysis {
     /// The Config used to generate this analysis data.
     pub config: Config,
+    pub version: Option<String>,
     pub prelude: Option<CratePreludeData>,
     pub imports: Vec<Import>,
     pub defs: Vec<Def>,
@@ -50,6 +51,7 @@ impl Analysis {
     pub fn new(config: Config) -> Analysis {
         Analysis {
             config,
+            version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
             prelude: None,
             imports: vec![],
             defs: vec![],
@@ -64,6 +66,7 @@ impl Analysis {
     pub fn new(config: Config) -> Analysis {
         Analysis {
             config,
+            version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
             prelude: None,
             imports: vec![],
             defs: vec![],


### PR DESCRIPTION
Per the discussion at https://github.com/nrc/rls-analysis/issues/130#issuecomment-368338186 it is desirable to have the `rls-data` crate version number baked into the serialized data. This should accomplish the job, I think, since it looks like the `librustc_save_analysis` code just uses the the built-in serializer for `rls-data`.

Already the `rls-analysis` and `librustc_save_analysis` code is required to use the same `rls-data` version in order to be compatible, but this change will enable us to do a better job of checking compatibility at runtime and instead of silently failing. i.e. in the [read_crate_data](https://github.com/nrc/rls-analysis/blob/9be0f2115cb67972cd93563c20cd4c2601446151/src/raw.rs#L111) function we should be able to now report the version of `rls-data` that was used to produce the saved file.