### PR TITLE
Add DefKind variants for foreign functions and statics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-data"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-data"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Data structures used by the RLS and Rust compiler"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub enum DefKind {
     Trait,
     // value = type + generics
     Function,
+    ForeignFunction,
     // value = type + generics
     Method,
     // No id, no value.
@@ -209,6 +210,7 @@ pub enum DefKind {
     // value = type and init expression (for all variable kinds).
     Local,
     Static,
+    ForeignStatic,
     Const,
     Field,
     // no value


### PR DESCRIPTION
This looked cleaner since there are going to be other DefKinds for foreign types
and such, looking at rustc's source.

Fixes #17