### PR TITLE
Include more info the rustc invocation/compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub struct Analysis {
     /// The Config used to generate this analysis data.
     pub config: Config,
     pub version: Option<String>,
+    pub compilation: Option<CompilationOptions>,
     pub prelude: Option<CratePreludeData>,
     pub imports: Vec<Import>,
     pub defs: Vec<Def>,
@@ -53,6 +54,7 @@ impl Analysis {
             config,
             version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
             prelude: None,
+            compilation: None,
             imports: vec![],
             defs: vec![],
             impls: vec![],
@@ -113,6 +115,16 @@ pub struct SpanData {
     // Character offset.
     pub column_start: span::Column<span::OneIndexed>,
     pub column_end: span::Column<span::OneIndexed>,
+}
+
+#[cfg_attr(feature = "serialize-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serialize-rustc", derive(RustcDecodable, RustcEncodable))]
+#[derive(Debug, Clone)]
+pub struct CompilationOptions {
+    pub directory: PathBuf,
+    pub program: String,
+    pub arguments: Vec<String>,
+    pub output: PathBuf,
 }
 
 #[cfg_attr(feature = "serialize-serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This is a proposal for what we might include about a given crate compilation. The most important one is the invocation, which can be used to possibly recreate a build plan of sorts from a set of save analysis JSON files. However, there are also other options included that might be handy, such as info whether this is a unit test harness mode, used sysroot, target triple and also where are the actual external crate files.

Additionally, I think it might also be useful to include `cfg` options (which I did at first, but decided that it's not as crucial now and can possibly be added later), which might be useful for the RLS and other consumers.

I'll also push a PR against Rust repo shortly, referencing this branch.
@nrc is this okay for now?